### PR TITLE
Fix websocket hook error message

### DIFF
--- a/web/src/hooks/use-websocket.tsx
+++ b/web/src/hooks/use-websocket.tsx
@@ -164,7 +164,7 @@ export function useWebsocket() {
   const context = useContext(WebSocketContext);
   if (context === undefined) {
     throw new Error(
-      "useTelegramWebSocket must be used within a WebSocketProvider",
+      "useWebsocket must be used within a WebSocketProvider",
     );
   }
   return context;


### PR DESCRIPTION
## Summary
- update hook error message in `use-websocket.tsx`

## Testing
- `npm run typecheck` in `web`
- `SKIP_ENV_VALIDATION=1 npm run lint` in `web`
- `./gradlew test --no-daemon` *(fails: NoClassDefFoundError at Config.java)*

------
https://chatgpt.com/codex/tasks/task_b_685087c690a88321af5756219a37dbe6